### PR TITLE
Add VST3 Resonance Detector plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Build directories
+build/
+cmake-build-*/
+Builds/
+
+# IDE files
+.vs/
+.vscode/
+.idea/
+*.suo
+*.user
+*.sln.docstates
+
+# Compiled files
+*.o
+*.obj
+*.exe
+*.dll
+*.so
+*.dylib
+*.a
+*.lib
+
+# CMake
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+install_manifest.txt
+
+# JUCE
+JuceLibraryCode/
+*.jucer
+
+# macOS
+.DS_Store
+*.dSYM/
+
+# Windows
+*.pdb
+*.ilk
+*.exp
+
+# VST3
+*.vst3
+
+# Dependencies
+_deps/

--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -1,0 +1,154 @@
+# Resonance Detector VST3 빌드 가이드
+
+이 문서는 Resonance Detector VST3 플러그인을 빌드하는 상세한 가이드입니다.
+
+## 사전 준비
+
+### Windows
+
+1. **Visual Studio 2019 이상** 설치
+   - "C++를 사용한 데스크톱 개발" 워크로드 선택
+   - CMake 도구 포함
+
+2. **CMake** (Visual Studio에 포함되지 않은 경우)
+   - https://cmake.org/download/ 에서 다운로드
+   - 설치 시 "Add CMake to system PATH" 옵션 선택
+
+### macOS
+
+1. **Xcode** 설치
+   ```bash
+   xcode-select --install
+   ```
+
+2. **CMake** 설치
+   ```bash
+   brew install cmake
+   ```
+
+### Linux (Ubuntu/Debian)
+
+```bash
+sudo apt-get update
+sudo apt-get install build-essential cmake git
+sudo apt-get install libasound2-dev libx11-dev libxext-dev libxrandr-dev \
+                     libxinerama-dev libxcursor-dev libfreetype6-dev \
+                     libgl1-mesa-dev
+```
+
+## 빌드 프로세스
+
+### 1. 저장소 클론
+
+```bash
+git clone https://github.com/flaresoft/TH_Tried.git
+cd TH_Tried
+```
+
+### 2. 빌드 디렉토리 생성
+
+```bash
+mkdir build
+cd build
+```
+
+### 3. CMake 구성
+
+#### Windows (Visual Studio)
+```bash
+cmake .. -G "Visual Studio 16 2019" -A x64
+```
+
+#### macOS / Linux
+```bash
+cmake .. -DCMAKE_BUILD_TYPE=Release
+```
+
+### 4. 빌드 실행
+
+#### Windows
+```bash
+cmake --build . --config Release
+```
+
+또는 Visual Studio에서 생성된 `.sln` 파일을 열어서 빌드할 수 있습니다.
+
+#### macOS / Linux
+```bash
+cmake --build . --config Release -j 4
+```
+
+(`-j 4`는 4개의 CPU 코어를 사용하여 병렬 빌드를 수행합니다)
+
+## 빌드 결과물
+
+빌드가 성공하면 다음 위치에서 플러그인을 찾을 수 있습니다:
+
+- **Windows**: `build\ResonanceDetector_artefacts\Release\VST3\ResonanceDetector.vst3`
+- **macOS**: `build/ResonanceDetector_artefacts/Release/VST3/ResonanceDetector.vst3`
+- **Linux**: `build/ResonanceDetector_artefacts/Release/VST3/ResonanceDetector.vst3`
+
+## 플러그인 설치
+
+빌드된 VST3 파일을 DAW가 인식할 수 있는 위치로 복사합니다:
+
+### Windows
+```bash
+copy build\ResonanceDetector_artefacts\Release\VST3\ResonanceDetector.vst3 "%CommonProgramFiles%\VST3\"
+```
+
+### macOS
+```bash
+cp -r build/ResonanceDetector_artefacts/Release/VST3/ResonanceDetector.vst3 ~/Library/Audio/Plug-Ins/VST3/
+```
+
+### Linux
+```bash
+mkdir -p ~/.vst3
+cp -r build/ResonanceDetector_artefacts/Release/VST3/ResonanceDetector.vst3 ~/.vst3/
+```
+
+## 문제 해결
+
+### JUCE 다운로드 실패
+
+CMake가 JUCE를 자동으로 다운로드하지 못하는 경우:
+
+1. 수동으로 JUCE를 다운로드:
+   ```bash
+   git clone --branch 7.0.9 https://github.com/juce-framework/JUCE.git
+   ```
+
+2. CMakeLists.txt에서 `FetchContent_Declare` 부분을 수정:
+   ```cmake
+   set(JUCE_DIR "${CMAKE_SOURCE_DIR}/JUCE")
+   add_subdirectory(${JUCE_DIR})
+   ```
+
+### 컴파일 오류
+
+- C++17 지원 확인: 컴파일러가 C++17을 지원하는지 확인하세요
+- JUCE 버전: JUCE 7.0.9 이상을 사용하고 있는지 확인하세요
+
+### DAW에서 플러그인이 보이지 않음
+
+1. DAW를 재시작합니다
+2. DAW의 플러그인 스캔 기능을 실행합니다
+3. VST3 경로가 올바른지 확인합니다
+
+## 개발 모드
+
+개발 중에는 다음과 같이 디버그 빌드를 사용할 수 있습니다:
+
+```bash
+cmake .. -DCMAKE_BUILD_TYPE=Debug
+cmake --build . --config Debug
+```
+
+디버그 빌드는 더 많은 로깅과 어설션을 포함하여 문제 진단에 도움이 됩니다.
+
+## 추가 정보
+
+- JUCE 프레임워크: https://juce.com/
+- VST3 SDK 문서: https://steinbergmedia.github.io/vst3_doc/
+- 문제가 발생하면 GitHub Issues에 보고해주세요: https://github.com/flaresoft/TH_Tried/issues

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(ResonanceDetector VERSION 1.0.0)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Add JUCE as a subdirectory (you'll need to clone JUCE or add it as a submodule)
+# For now, we'll use FetchContent to download JUCE
+include(FetchContent)
+
+FetchContent_Declare(
+    JUCE
+    GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
+    GIT_TAG 7.0.9
+)
+
+FetchContent_MakeAvailable(JUCE)
+
+# Create the VST3 plugin
+juce_add_plugin(ResonanceDetector
+    COMPANY_NAME "FlareStudio"
+    IS_SYNTH FALSE
+    NEEDS_MIDI_INPUT FALSE
+    NEEDS_MIDI_OUTPUT FALSE
+    IS_MIDI_EFFECT FALSE
+    EDITOR_WANTS_KEYBOARD_FOCUS FALSE
+    COPY_PLUGIN_AFTER_BUILD TRUE
+    PLUGIN_MANUFACTURER_CODE Flre
+    PLUGIN_CODE Rsdt
+    FORMATS VST3
+    PRODUCT_NAME "Resonance Detector"
+)
+
+# Add source files
+target_sources(ResonanceDetector
+    PRIVATE
+        Source/PluginProcessor.cpp
+        Source/PluginEditor.cpp
+        Source/ResonanceDetector.cpp
+)
+
+# Add header files
+target_include_directories(ResonanceDetector
+    PUBLIC
+        Source
+)
+
+# Link JUCE modules
+target_compile_definitions(ResonanceDetector
+    PUBLIC
+        JUCE_WEB_BROWSER=0
+        JUCE_USE_CURL=0
+        JUCE_VST3_CAN_REPLACE_VST2=0
+)
+
+target_link_libraries(ResonanceDetector
+    PRIVATE
+        juce::juce_audio_utils
+        juce::juce_dsp
+    PUBLIC
+        juce::juce_recommended_config_flags
+        juce::juce_recommended_lto_flags
+        juce::juce_recommended_warning_flags
+)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
-# TH_Tried
+# Resonance Detector VST3 Plugin
+
+Studio One 7 호환 VST3 플러그인 - 실시간 레조넌스 감지 및 표시
+
+## 기능
+
+- **실시간 레조넌스 감지**: FFT 분석을 통해 오디오 신호에서 레조넌스를 자동으로 감지합니다
+- **주파수 맵 시각화**: 20Hz ~ 20kHz 범위의 주파수 스펙트럼과 감지된 레조넌스를 시각적으로 표시
+- **지속적인 레조넌스 추적**: 감지된 레조넌스는 Reset 버튼을 누르기 전까지 계속 유지됩니다
+- **Q 팩터 표시**: 각 레조넌스의 품질 계수(Q Factor)를 함께 표시
+
+## 빌드 방법
+
+### 필수 요구사항
+
+- CMake 3.15 이상
+- C++17 호환 컴파일러
+  - Windows: Visual Studio 2019 이상
+  - macOS: Xcode 11 이상
+  - Linux: GCC 9 이상
+
+### 빌드 단계
+
+1. 저장소 클론:
+```bash
+git clone https://github.com/flaresoft/TH_Tried.git
+cd TH_Tried
+```
+
+2. 빌드 디렉토리 생성 및 CMake 실행:
+```bash
+mkdir build
+cd build
+cmake ..
+```
+
+3. 빌드:
+```bash
+cmake --build . --config Release
+```
+
+빌드가 완료되면 VST3 플러그인이 자동으로 시스템의 VST3 플러그인 폴더에 복사됩니다.
+
+### VST3 플러그인 위치
+
+- **Windows**: `C:\Program Files\Common Files\VST3\`
+- **macOS**: `~/Library/Audio/Plug-Ins/VST3/` 또는 `/Library/Audio/Plug-Ins/VST3/`
+- **Linux**: `~/.vst3/`
+
+## 사용 방법
+
+1. Studio One 7에서 오디오 트랙 또는 악기 트랙에 "Resonance Detector" 플러그인을 추가합니다
+2. 오디오를 재생하면 실시간으로 레조넌스가 감지되어 주파수 맵에 표시됩니다
+3. 감지된 레조넌스는 빨간색 점으로 표시되며, 주파수와 Q 팩터 정보가 함께 표시됩니다
+4. "Reset Resonances" 버튼을 클릭하면 감지된 레조넌스를 초기화할 수 있습니다
+
+## 기술 상세
+
+- **FFT 크기**: 8192 샘플 (고해상도 주파수 분석)
+- **윈도우 함수**: Hann 윈도우
+- **최소 Q 팩터**: 2.0 (낮은 Q 값의 노이즈 필터링)
+- **주파수 범위**: 20Hz ~ 20kHz
+- **UI 업데이트 속도**: 30 FPS
+
+## 라이선스
+
+MIT License
+
+## 기여
+
+이슈 및 풀 리퀘스트를 환영합니다!

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -1,0 +1,215 @@
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+
+// FrequencyMapComponent implementation
+FrequencyMapComponent::FrequencyMapComponent(ResonanceDetectorAudioProcessor& p)
+    : audioProcessor(p)
+{
+    startTimerHz(30); // 30 FPS refresh rate
+}
+
+FrequencyMapComponent::~FrequencyMapComponent()
+{
+    stopTimer();
+}
+
+void FrequencyMapComponent::paint(juce::Graphics& g)
+{
+    g.fillAll(juce::Colour(0xff1a1a1a));
+
+    plotArea = getLocalBounds().reduced(40, 20);
+
+    drawFrequencyGrid(g);
+    drawSpectrum(g);
+    drawResonances(g);
+}
+
+void FrequencyMapComponent::resized()
+{
+}
+
+void FrequencyMapComponent::timerCallback()
+{
+    repaint();
+}
+
+void FrequencyMapComponent::drawFrequencyGrid(juce::Graphics& g)
+{
+    g.setColour(juce::Colour(0xff404040));
+
+    // Draw frequency grid lines
+    const float frequencies[] = { 20.0f, 50.0f, 100.0f, 200.0f, 500.0f, 1000.0f,
+                                  2000.0f, 5000.0f, 10000.0f, 20000.0f };
+
+    for (float freq : frequencies)
+    {
+        float x = frequencyToX(freq);
+        g.drawLine(x, plotArea.getY(), x, plotArea.getBottom(), 1.0f);
+
+        // Draw frequency labels
+        g.setColour(juce::Colour(0xff808080));
+        juce::String label;
+        if (freq >= 1000.0f)
+            label = juce::String(freq / 1000.0f, 1) + "k";
+        else
+            label = juce::String(static_cast<int>(freq));
+
+        g.drawText(label, static_cast<int>(x) - 20, plotArea.getBottom() + 5, 40, 15,
+                   juce::Justification::centred);
+        g.setColour(juce::Colour(0xff404040));
+    }
+
+    // Draw magnitude grid lines
+    for (int db = -60; db <= 0; db += 10)
+    {
+        float magnitude = juce::Decibels::decibelsToGain(static_cast<float>(db));
+        float y = magnitudeToY(magnitude);
+        g.drawLine(plotArea.getX(), y, plotArea.getRight(), y, 1.0f);
+
+        // Draw dB labels
+        g.setColour(juce::Colour(0xff808080));
+        g.drawText(juce::String(db) + " dB", plotArea.getX() - 35, static_cast<int>(y) - 7,
+                   30, 14, juce::Justification::right);
+        g.setColour(juce::Colour(0xff404040));
+    }
+}
+
+void FrequencyMapComponent::drawSpectrum(juce::Graphics& g)
+{
+    auto fftData = audioProcessor.getCurrentFFTData();
+    if (fftData.empty())
+        return;
+
+    juce::Path spectrumPath;
+    bool started = false;
+
+    const int numBins = static_cast<int>(fftData.size());
+    const double sampleRate = audioProcessor.getSampleRate();
+
+    for (int i = 1; i < numBins; ++i)
+    {
+        float frequency = (i * static_cast<float>(sampleRate)) / (numBins * 2);
+
+        if (frequency < 20.0f || frequency > 20000.0f)
+            continue;
+
+        float x = frequencyToX(frequency);
+        float y = magnitudeToY(fftData[i]);
+
+        if (!started)
+        {
+            spectrumPath.startNewSubPath(x, y);
+            started = true;
+        }
+        else
+        {
+            spectrumPath.lineTo(x, y);
+        }
+    }
+
+    g.setColour(juce::Colour(0xff00aaff).withAlpha(0.6f));
+    g.strokePath(spectrumPath, juce::PathStrokeType(1.5f));
+}
+
+void FrequencyMapComponent::drawResonances(juce::Graphics& g)
+{
+    auto resonances = audioProcessor.getDetectedResonances();
+
+    for (const auto& peak : resonances)
+    {
+        if (peak.frequency < 20.0f || peak.frequency > 20000.0f)
+            continue;
+
+        float x = frequencyToX(peak.frequency);
+        float y = magnitudeToY(peak.magnitude);
+
+        // Draw resonance marker
+        g.setColour(juce::Colours::red);
+        g.fillEllipse(x - 4, y - 4, 8, 8);
+
+        // Draw vertical line
+        g.setColour(juce::Colours::red.withAlpha(0.5f));
+        g.drawLine(x, plotArea.getY(), x, plotArea.getBottom(), 1.0f);
+
+        // Draw frequency label
+        g.setColour(juce::Colours::white);
+        juce::String freqLabel;
+        if (peak.frequency >= 1000.0f)
+            freqLabel = juce::String(peak.frequency / 1000.0f, 2) + " kHz";
+        else
+            freqLabel = juce::String(static_cast<int>(peak.frequency)) + " Hz";
+
+        freqLabel += "\nQ: " + juce::String(peak.qFactor, 1);
+
+        g.drawText(freqLabel, static_cast<int>(x) - 40, static_cast<int>(y) - 35,
+                   80, 30, juce::Justification::centred);
+    }
+}
+
+float FrequencyMapComponent::frequencyToX(float frequency) const
+{
+    // Logarithmic frequency scale (20 Hz to 20 kHz)
+    const float minFreq = 20.0f;
+    const float maxFreq = 20000.0f;
+
+    float normalized = (std::log10(frequency) - std::log10(minFreq)) /
+                       (std::log10(maxFreq) - std::log10(minFreq));
+
+    return plotArea.getX() + normalized * plotArea.getWidth();
+}
+
+float FrequencyMapComponent::magnitudeToY(float magnitude) const
+{
+    // Convert to dB and map to Y position
+    float db = juce::Decibels::gainToDecibels(magnitude, -60.0f);
+    float normalized = juce::jmap(db, -60.0f, 0.0f, 1.0f, 0.0f);
+
+    return plotArea.getY() + normalized * plotArea.getHeight();
+}
+
+// ResonanceDetectorAudioProcessorEditor implementation
+ResonanceDetectorAudioProcessorEditor::ResonanceDetectorAudioProcessorEditor(ResonanceDetectorAudioProcessor& p)
+    : AudioProcessorEditor(&p)
+    , audioProcessor(p)
+    , frequencyMap(p)
+{
+    addAndMakeVisible(frequencyMap);
+    addAndMakeVisible(resetButton);
+
+    resetButton.setButtonText("Reset Resonances");
+    resetButton.onClick = [this]
+    {
+        audioProcessor.resetResonances();
+    };
+
+    setSize(800, 500);
+}
+
+ResonanceDetectorAudioProcessorEditor::~ResonanceDetectorAudioProcessorEditor()
+{
+}
+
+void ResonanceDetectorAudioProcessorEditor::paint(juce::Graphics& g)
+{
+    g.fillAll(juce::Colour(0xff2a2a2a));
+
+    g.setColour(juce::Colours::white);
+    g.setFont(20.0f);
+    g.drawText("Resonance Detector", getLocalBounds().removeFromTop(40),
+               juce::Justification::centred);
+}
+
+void ResonanceDetectorAudioProcessorEditor::resized()
+{
+    auto bounds = getLocalBounds();
+
+    // Title area
+    bounds.removeFromTop(40);
+
+    // Reset button at bottom
+    auto buttonArea = bounds.removeFromBottom(50);
+    resetButton.setBounds(buttonArea.reduced(20, 10));
+
+    // Frequency map in the middle
+    frequencyMap.setBounds(bounds);
+}

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <JuceHeader.h>
+#include "PluginProcessor.h"
+
+class FrequencyMapComponent : public juce::Component, private juce::Timer
+{
+public:
+    FrequencyMapComponent(ResonanceDetectorAudioProcessor& p);
+    ~FrequencyMapComponent() override;
+
+    void paint(juce::Graphics& g) override;
+    void resized() override;
+
+private:
+    void timerCallback() override;
+    void drawFrequencyGrid(juce::Graphics& g);
+    void drawSpectrum(juce::Graphics& g);
+    void drawResonances(juce::Graphics& g);
+    float frequencyToX(float frequency) const;
+    float magnitudeToY(float magnitude) const;
+
+    ResonanceDetectorAudioProcessor& audioProcessor;
+    juce::Rectangle<int> plotArea;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(FrequencyMapComponent)
+};
+
+class ResonanceDetectorAudioProcessorEditor : public juce::AudioProcessorEditor
+{
+public:
+    ResonanceDetectorAudioProcessorEditor(ResonanceDetectorAudioProcessor&);
+    ~ResonanceDetectorAudioProcessorEditor() override;
+
+    void paint(juce::Graphics&) override;
+    void resized() override;
+
+private:
+    ResonanceDetectorAudioProcessor& audioProcessor;
+
+    FrequencyMapComponent frequencyMap;
+    juce::TextButton resetButton;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ResonanceDetectorAudioProcessorEditor)
+};

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -1,0 +1,183 @@
+#include "PluginProcessor.h"
+#include "PluginEditor.h"
+
+ResonanceDetectorAudioProcessor::ResonanceDetectorAudioProcessor()
+    : AudioProcessor(BusesProperties()
+                     .withInput("Input", juce::AudioChannelSet::stereo(), true)
+                     .withOutput("Output", juce::AudioChannelSet::stereo(), true))
+{
+}
+
+ResonanceDetectorAudioProcessor::~ResonanceDetectorAudioProcessor()
+{
+}
+
+const juce::String ResonanceDetectorAudioProcessor::getName() const
+{
+    return JucePlugin_Name;
+}
+
+bool ResonanceDetectorAudioProcessor::acceptsMidi() const
+{
+    return false;
+}
+
+bool ResonanceDetectorAudioProcessor::producesMidi() const
+{
+    return false;
+}
+
+bool ResonanceDetectorAudioProcessor::isMidiEffect() const
+{
+    return false;
+}
+
+double ResonanceDetectorAudioProcessor::getTailLengthSeconds() const
+{
+    return 0.0;
+}
+
+int ResonanceDetectorAudioProcessor::getNumPrograms()
+{
+    return 1;
+}
+
+int ResonanceDetectorAudioProcessor::getCurrentProgram()
+{
+    return 0;
+}
+
+void ResonanceDetectorAudioProcessor::setCurrentProgram(int index)
+{
+    juce::ignoreUnused(index);
+}
+
+const juce::String ResonanceDetectorAudioProcessor::getProgramName(int index)
+{
+    juce::ignoreUnused(index);
+    return {};
+}
+
+void ResonanceDetectorAudioProcessor::changeProgramName(int index, const juce::String& newName)
+{
+    juce::ignoreUnused(index, newName);
+}
+
+void ResonanceDetectorAudioProcessor::prepareToPlay(double sampleRate, int samplesPerBlock)
+{
+    resonanceDetector.prepare(sampleRate, samplesPerBlock);
+}
+
+void ResonanceDetectorAudioProcessor::releaseResources()
+{
+}
+
+bool ResonanceDetectorAudioProcessor::isBusesLayoutSupported(const BusesLayout& layouts) const
+{
+    if (layouts.getMainOutputChannelSet() != juce::AudioChannelSet::mono()
+     && layouts.getMainOutputChannelSet() != juce::AudioChannelSet::stereo())
+        return false;
+
+    if (layouts.getMainOutputChannelSet() != layouts.getMainInputChannelSet())
+        return false;
+
+    return true;
+}
+
+void ResonanceDetectorAudioProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
+{
+    juce::ignoreUnused(midiMessages);
+    juce::ScopedNoDenormals noDenormals;
+
+    auto totalNumInputChannels = getTotalNumInputChannels();
+    auto totalNumOutputChannels = getTotalNumOutputChannels();
+
+    // Clear unused output channels
+    for (auto i = totalNumInputChannels; i < totalNumOutputChannels; ++i)
+        buffer.clear(i, 0, buffer.getNumSamples());
+
+    // Process audio for resonance detection (mix to mono if stereo)
+    if (totalNumInputChannels > 0)
+    {
+        const int numSamples = buffer.getNumSamples();
+        std::vector<float> monoBuffer(numSamples);
+
+        // Mix to mono
+        for (int channel = 0; channel < totalNumInputChannels; ++channel)
+        {
+            const float* channelData = buffer.getReadPointer(channel);
+            for (int i = 0; i < numSamples; ++i)
+            {
+                monoBuffer[i] += channelData[i] / totalNumInputChannels;
+            }
+        }
+
+        // Process through resonance detector
+        resonanceDetector.process(monoBuffer.data(), numSamples);
+    }
+}
+
+bool ResonanceDetectorAudioProcessor::hasEditor() const
+{
+    return true;
+}
+
+juce::AudioProcessorEditor* ResonanceDetectorAudioProcessor::createEditor()
+{
+    return new ResonanceDetectorAudioProcessorEditor(*this);
+}
+
+void ResonanceDetectorAudioProcessor::getStateInformation(juce::MemoryBlock& destData)
+{
+    // Save detected resonances
+    auto resonances = resonanceDetector.getDetectedResonances();
+    juce::MemoryOutputStream stream(destData, false);
+
+    stream.writeInt(static_cast<int>(resonances.size()));
+    for (const auto& peak : resonances)
+    {
+        stream.writeFloat(peak.frequency);
+        stream.writeFloat(peak.magnitude);
+        stream.writeFloat(peak.qFactor);
+    }
+}
+
+void ResonanceDetectorAudioProcessor::setStateInformation(const void* data, int sizeInBytes)
+{
+    // Restore detected resonances
+    juce::MemoryInputStream stream(data, static_cast<size_t>(sizeInBytes), false);
+
+    int numResonances = stream.readInt();
+    std::vector<ResonancePeak> resonances;
+
+    for (int i = 0; i < numResonances; ++i)
+    {
+        ResonancePeak peak;
+        peak.frequency = stream.readFloat();
+        peak.magnitude = stream.readFloat();
+        peak.qFactor = stream.readFloat();
+        resonances.push_back(peak);
+    }
+
+    resonanceDetector.restoreResonances(resonances);
+}
+
+std::vector<ResonancePeak> ResonanceDetectorAudioProcessor::getDetectedResonances() const
+{
+    return resonanceDetector.getDetectedResonances();
+}
+
+void ResonanceDetectorAudioProcessor::resetResonances()
+{
+    resonanceDetector.reset();
+}
+
+std::vector<float> ResonanceDetectorAudioProcessor::getCurrentFFTData() const
+{
+    return resonanceDetector.getCurrentFFTData();
+}
+
+juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
+{
+    return new ResonanceDetectorAudioProcessor();
+}

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <JuceHeader.h>
+#include "ResonanceDetector.h"
+
+class ResonanceDetectorAudioProcessor : public juce::AudioProcessor
+{
+public:
+    ResonanceDetectorAudioProcessor();
+    ~ResonanceDetectorAudioProcessor() override;
+
+    void prepareToPlay(double sampleRate, int samplesPerBlock) override;
+    void releaseResources() override;
+
+    bool isBusesLayoutSupported(const BusesLayout& layouts) const override;
+
+    void processBlock(juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+
+    juce::AudioProcessorEditor* createEditor() override;
+    bool hasEditor() const override;
+
+    const juce::String getName() const override;
+
+    bool acceptsMidi() const override;
+    bool producesMidi() const override;
+    bool isMidiEffect() const override;
+    double getTailLengthSeconds() const override;
+
+    int getNumPrograms() override;
+    int getCurrentProgram() override;
+    void setCurrentProgram(int index) override;
+    const juce::String getProgramName(int index) override;
+    void changeProgramName(int index, const juce::String& newName) override;
+
+    void getStateInformation(juce::MemoryBlock& destData) override;
+    void setStateInformation(const void* data, int sizeInBytes) override;
+
+    // Get detected resonances
+    std::vector<ResonancePeak> getDetectedResonances() const;
+
+    // Reset detected resonances
+    void resetResonances();
+
+    // Get current FFT data for visualization
+    std::vector<float> getCurrentFFTData() const;
+
+private:
+    ResonanceDetector resonanceDetector;
+    juce::AudioBuffer<float> bufferCopy;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ResonanceDetectorAudioProcessor)
+};

--- a/Source/ResonanceDetector.cpp
+++ b/Source/ResonanceDetector.cpp
@@ -1,0 +1,210 @@
+#include "ResonanceDetector.h"
+
+ResonanceDetector::ResonanceDetector()
+    : fft(FFT_ORDER)
+    , window(FFT_SIZE, juce::dsp::WindowingFunction<float>::hann)
+    , fftData(FFT_SIZE * 2, 0.0f)
+    , fifo(FFT_SIZE, 0.0f)
+    , fifoIndex(0)
+    , currentSpectrum(FFT_SIZE / 2, 0.0f)
+    , sampleRate_(44100.0)
+    , minMagnitudeThreshold(0.01f)  // -40 dB
+    , minQFactor(2.0f)               // Minimum Q factor for resonance
+{
+}
+
+ResonanceDetector::~ResonanceDetector()
+{
+}
+
+void ResonanceDetector::prepare(double sampleRate, int samplesPerBlock)
+{
+    juce::ignoreUnused(samplesPerBlock);
+    sampleRate_ = sampleRate;
+}
+
+void ResonanceDetector::process(const float* audioData, int numSamples)
+{
+    // Fill FIFO buffer
+    for (int i = 0; i < numSamples; ++i)
+    {
+        fifo[fifoIndex] = audioData[i];
+        fifoIndex++;
+
+        // When FIFO is full, perform FFT
+        if (fifoIndex >= FFT_SIZE)
+        {
+            fifoIndex = 0;
+
+            // Copy FIFO to FFT data
+            std::copy(fifo.begin(), fifo.end(), fftData.begin());
+
+            // Apply window
+            window.multiplyWithWindowingTable(fftData.data(), FFT_SIZE);
+
+            // Perform FFT
+            fft.performFrequencyOnlyForwardTransform(fftData.data());
+
+            // Store current spectrum for visualization
+            for (int j = 0; j < FFT_SIZE / 2; ++j)
+            {
+                currentSpectrum[j] = fftData[j];
+            }
+
+            // Detect resonances
+            detectResonances();
+        }
+    }
+}
+
+void ResonanceDetector::detectResonances()
+{
+    std::vector<float> magnitudes(FFT_SIZE / 2);
+
+    // Convert to dB and normalize
+    float maxMagnitude = 0.0f;
+    for (int i = 0; i < FFT_SIZE / 2; ++i)
+    {
+        magnitudes[i] = fftData[i];
+        maxMagnitude = std::max(maxMagnitude, magnitudes[i]);
+    }
+
+    if (maxMagnitude < 1e-6f)
+        return;
+
+    // Normalize
+    for (auto& mag : magnitudes)
+    {
+        mag /= maxMagnitude;
+    }
+
+    // Find peaks using simple peak detection
+    // A peak is a local maximum that exceeds threshold and has sufficient Q
+    for (int i = 10; i < FFT_SIZE / 2 - 10; ++i) // Skip DC and very low/high frequencies
+    {
+        float currentMag = magnitudes[i];
+
+        // Check if it's a local maximum
+        bool isPeak = true;
+        for (int j = -5; j <= 5; ++j)
+        {
+            if (j != 0 && magnitudes[i + j] > currentMag)
+            {
+                isPeak = false;
+                break;
+            }
+        }
+
+        if (isPeak && currentMag > minMagnitudeThreshold)
+        {
+            // Calculate Q factor
+            float q = calculateQFactor(i, magnitudes);
+
+            if (q >= minQFactor)
+            {
+                // Calculate frequency
+                float frequency = (i * static_cast<float>(sampleRate_)) / FFT_SIZE;
+
+                ResonancePeak peak;
+                peak.frequency = frequency;
+                peak.magnitude = currentMag;
+                peak.qFactor = q;
+
+                addResonance(peak);
+            }
+        }
+    }
+}
+
+float ResonanceDetector::calculateQFactor(int binIndex, const std::vector<float>& magnitudes)
+{
+    float peakMag = magnitudes[binIndex];
+    float halfPowerLevel = peakMag / std::sqrt(2.0f);
+
+    // Find -3dB points (half power)
+    int lowerBin = binIndex;
+    int upperBin = binIndex;
+
+    // Find lower -3dB point
+    for (int i = binIndex - 1; i >= 1; --i)
+    {
+        if (magnitudes[i] <= halfPowerLevel)
+        {
+            lowerBin = i;
+            break;
+        }
+    }
+
+    // Find upper -3dB point
+    for (int i = binIndex + 1; i < static_cast<int>(magnitudes.size()) - 1; ++i)
+    {
+        if (magnitudes[i] <= halfPowerLevel)
+        {
+            upperBin = i;
+            break;
+        }
+    }
+
+    // Calculate Q factor: Q = f0 / (f2 - f1)
+    float centerFreq = (binIndex * static_cast<float>(sampleRate_)) / FFT_SIZE;
+    float lowerFreq = (lowerBin * static_cast<float>(sampleRate_)) / FFT_SIZE;
+    float upperFreq = (upperBin * static_cast<float>(sampleRate_)) / FFT_SIZE;
+
+    float bandwidth = upperFreq - lowerFreq;
+
+    if (bandwidth < 1.0f)
+        bandwidth = 1.0f;
+
+    return centerFreq / bandwidth;
+}
+
+void ResonanceDetector::addResonance(const ResonancePeak& peak)
+{
+    juce::ScopedLock lock(resonanceLock);
+
+    // Check if similar resonance already exists
+    bool found = false;
+    for (auto& existing : detectedResonances)
+    {
+        if (existing.isSimilar(peak, 10.0f))
+        {
+            // Update if new peak has higher magnitude
+            if (peak.magnitude > existing.magnitude)
+            {
+                detectedResonances.erase(existing);
+                detectedResonances.insert(peak);
+            }
+            found = true;
+            break;
+        }
+    }
+
+    if (!found)
+    {
+        detectedResonances.insert(peak);
+    }
+}
+
+void ResonanceDetector::reset()
+{
+    juce::ScopedLock lock(resonanceLock);
+    detectedResonances.clear();
+}
+
+std::vector<ResonancePeak> ResonanceDetector::getDetectedResonances() const
+{
+    juce::ScopedLock lock(resonanceLock);
+    return std::vector<ResonancePeak>(detectedResonances.begin(), detectedResonances.end());
+}
+
+void ResonanceDetector::restoreResonances(const std::vector<ResonancePeak>& resonances)
+{
+    juce::ScopedLock lock(resonanceLock);
+    detectedResonances.clear();
+    detectedResonances.insert(resonances.begin(), resonances.end());
+}
+
+std::vector<float> ResonanceDetector::getCurrentFFTData() const
+{
+    return currentSpectrum;
+}

--- a/Source/ResonanceDetector.h
+++ b/Source/ResonanceDetector.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <JuceHeader.h>
+#include <vector>
+#include <set>
+
+struct ResonancePeak
+{
+    float frequency;
+    float magnitude;
+    float qFactor;
+
+    bool operator<(const ResonancePeak& other) const
+    {
+        return frequency < other.frequency;
+    }
+
+    bool isSimilar(const ResonancePeak& other, float frequencyTolerance = 5.0f) const
+    {
+        return std::abs(frequency - other.frequency) < frequencyTolerance;
+    }
+};
+
+class ResonanceDetector
+{
+public:
+    ResonanceDetector();
+    ~ResonanceDetector();
+
+    void prepare(double sampleRate, int samplesPerBlock);
+    void process(const float* audioData, int numSamples);
+    void reset();
+
+    std::vector<ResonancePeak> getDetectedResonances() const;
+    void restoreResonances(const std::vector<ResonancePeak>& resonances);
+    std::vector<float> getCurrentFFTData() const;
+
+private:
+    void detectResonances();
+    float calculateQFactor(int binIndex, const std::vector<float>& magnitudes);
+    void addResonance(const ResonancePeak& peak);
+
+    static constexpr int FFT_ORDER = 13;
+    static constexpr int FFT_SIZE = 1 << FFT_ORDER; // 8192
+
+    juce::dsp::FFT fft;
+    juce::dsp::WindowingFunction<float> window;
+
+    std::vector<float> fftData;
+    std::vector<float> fifo;
+    int fifoIndex;
+
+    std::set<ResonancePeak> detectedResonances;
+    std::vector<float> currentSpectrum;
+
+    double sampleRate_;
+    float minMagnitudeThreshold;
+    float minQFactor;
+
+    juce::CriticalSection resonanceLock;
+};


### PR DESCRIPTION
Implement a real-time resonance detection VST3 plugin for Studio One 7.

Features:
- FFT-based resonance detection with 8192 sample resolution
- Real-time frequency spectrum visualization (20Hz - 20kHz)
- Persistent resonance tracking until manual reset
- Q-factor calculation and display for each detected resonance
- Interactive GUI with frequency map and reset functionality

Technical details:
- JUCE framework for cross-platform VST3 development
- Hann windowing for FFT analysis
- Logarithmic frequency scale for better visualization
- Thread-safe resonance data management
- 30 FPS UI refresh rate

Build system:
- CMake configuration for all platforms
- Automatic JUCE dependency fetching
- VST3 plugin format targeting Studio One 7